### PR TITLE
Release MazeBench 0.2.6

### DIFF
--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -32,7 +32,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.5"
+version = "0.2.6"
 description = "MazeBench: ice-maze puzzle site, world editor, and coding-agent benchmark runner. `mazebench launch` serves the website locally."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump the MazeBench root package from 0.2.5 to 0.2.6
- synchronize pyproject.toml, mazebench_cli.__version__, and uv.lock
- prepare the combined solver panel/export and agent Auto-Quit changes for PyPI

## Verification
- npm test
- node scripts/build-python-runtime.js
- built mazebench-0.2.6 wheel and source distribution
- installed the built wheel and verified launch routes on Python 3.9 and Python 3.14
- confirmed PyPI does not already contain 0.2.6
