### PR TITLE
Release MazeBench 0.2.9 and Prime environment 0.1.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v4
 
@@ -44,6 +46,9 @@ jobs:
           cache-dependency-glob: environments/mazebench/uv.lock
 
       - run: npm ci
+
+      - name: Install Chromium for vision integration tests
+        run: npx playwright-core install --with-deps chromium
 
       - name: Node test suite
         run: npm test

--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.7"
+version = "0.1.8"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -77,7 +77,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.7
+prime env install mazebench/mazebench@0.1.8
 ```
 
 ## Evaluate locally

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.7"
+version = "0.1.8"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },

--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -32,7 +32,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.8"
+version = "0.2.9"
 description = "MazeBench: ice-maze puzzle site, world editor, and coding-agent benchmark runner. `mazebench launch` serves the website locally."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump the PyPI package and CLI to 0.2.9
- bump the Prime environment and RL config to 0.1.8
- install Chromium in the PyPI workflow so the full vision integration proof runs during publishing

## Local validation
- full npm test suite, including real Chromium vision frames
- root wheel and sdist build plus Twine checks
- Python 3.9 and 3.14 wheel launch smokes
- Prime environment wheel build and packaged-file audit
- all 9 Prime harness certifications
- custom-harness isolation and deterministic resume checks