### PR TITLE
Forbid repository access in agent runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 These instructions apply to the entire MazeBenchEngine repository.
 
+## Absolute isolation for benchmark agent runs
+
+Benchmark agents must never be able to inspect MazeBenchEngine or any other repository. Treat repository or host-file access by the evaluated agent as cheating and as a run-launch failure, not as a supported tools mode.
+
+- This rule applies to every agent run and every launch variant, including local, subscription, container, host, vision, text, tools-on, tools-off, offline, omniscient, hidden-name, swarm, worker, clone, continuation, and branch runs. Do not add mode-specific exceptions.
+- Keep the trusted runner and game-control server separate from the evaluated agent. The runner may load the environment, but the evaluated model and every process or tool it can invoke must receive only the intended game observations and game-control interfaces.
+- Never give the evaluated agent a repository working directory, repository mount, `--add-dir`, readable or writable repository root, host shell, general command execution, filesystem search/read tool, coding tool, repository MCP resource, or repository path in its prompt or environment.
+- A tools-enabled benchmark may expose only explicitly approved game-control tools. `offline`, `mode=vision`, `omniscient=false`, or a workspace-write sandbox do not provide repository isolation and must never be treated as if they do.
+- Block access to source code, level definitions, world maps, solver code, tests, fixtures, hidden-state assets, scorecards, session files, run outputs, logs, prior-run artifacts, and sibling repositories. Do not allow indirect access through child processes, workers, clones, inherited file descriptors, symlinks, environment variables, or helper services.
+- Give each evaluated agent a fresh, empty, run-scoped workspace containing no copied or linked repository content. Keep any agent-created notes or artifacts there only when the benchmark explicitly permits them.
+- Launchers must fail closed before starting a run if the requested configuration, sandbox, tool set, working directory, mount set, or environment would expose repository or host files. Never silently launch with broader access.
+- When changing agent launch code, preserve this boundary with automated tests that assert the evaluated agent cannot read repository files or invoke general shell/file tools. A run that crosses this boundary is invalid even if it never changes game state.
+
 ## Branch-first development
 
 - Do not commit or push ordinary work directly to `main` unless the user explicitly overrides this rule.


### PR DESCRIPTION
## What changed

- Added an absolute isolation policy for every benchmark agent-run variant.
- Forbid repository working directories, mounts, `--add-dir`, host shell, general execution, filesystem tools, repository resources, and repository paths in the evaluated agent's prompt or environment.
- Require fresh empty run-scoped workspaces, game-control-only tools, fail-closed launch validation, and automated isolation tests.
- Explicitly classify access to level data, engine and solver source, session files, prior runs, logs, and sibling repositories as cheating that invalidates the run.

## Why

A tools-enabled vision run was allowed to inspect MazeBenchEngine source and level files. The existing repository instructions did not state the required trust boundary, and the launch configuration treated offline mode and a workspace-write sandbox as sufficient isolation.

## Impact

Future work on agent launchers must keep the trusted runner/game server separate from the evaluated agent and must reject any run configuration that exposes repository or host files, regardless of run mode.

## Validation

- `git diff --check`
- Documentation-only change; no runtime tests required.
