### PR TITLE
Add Prime action feedback

### DIFF
--- a/environments/mazebench/mazebench/mazebench.py
+++ b/environments/mazebench/mazebench/mazebench.py
@@ -410,14 +410,10 @@ def render_multiturn_user_prompt(
     target_text: str,
     result_text: str,
 ) -> str:
-    notice_parts: list[str] = []
-    if result_text.startswith("Previous response was invalid:"):
-        notice_parts.append(result_text)
-    warning_start = result_text.find("AUTO-QUIT WARNING:")
-    if warning_start >= 0:
-        notice_parts.append(result_text[warning_start:])
+    normalized_result = str(result_text or "").strip()
+    notice_parts: list[str] = [normalized_result] if normalized_result else []
     death = death_text(status)
-    if death:
+    if death and death not in normalized_result:
         notice_parts.append(death)
     return render_prompt_file(
         MULTITURN_USER_PROMPT_FILE,
@@ -1261,6 +1257,7 @@ def slim_status(status: dict[str, Any] | None) -> dict[str, Any]:
         "current_view",
         "death_message",
         "destination_room",
+        "direction",
         "game_lost",
         "game_won",
         "gem_count",

--- a/environments/mazebench/mazebench/prompts/multiturn_system.txt
+++ b/environments/mazebench/mazebench/prompts/multiturn_system.txt
@@ -1,7 +1,10 @@
 You are controlling a 3D grid game. Choose exactly one command each
 turn. For game actions, your entire response must be one exact command line.
 Do not include analysis, markdown, JSON, punctuation, or extra words.
-If you are unsure while the player is alive, respond with `up`.
+Use the previous action result in each observation to decide what to do next.
+If it says `Moved: false`, that movement was blocked. Do not repeat the same
+blocked movement unless another action has changed the board; choose a different
+valid command instead.
 
 You can see the conversation history. Use it as game memory: remember where you
 have been, useful map facts, failed moves, collected gems, and your current

--- a/scripts/maze-verify-prime-resume.py
+++ b/scripts/maze-verify-prime-resume.py
@@ -14,6 +14,7 @@ from mazebench.mazebench import (
     MazeBenchTaskset,
     MazeSession,
     load_prime_resume_checkpoint,
+    prime_resume_prompt,
     slim_status,
 )
 
@@ -136,6 +137,11 @@ def self_test() -> None:
             ),
             encoding="utf8",
         )
+        checkpoint = load_prime_resume_checkpoint(str(checkpoint_path))
+        resumed_prompt = prime_resume_prompt(checkpoint)[-1]["content"]
+        assert "Previous action: move." in resumed_prompt
+        assert "Direction: up." in resumed_prompt
+        assert "Moved: true." in resumed_prompt
         result = asyncio.run(verify(checkpoint_path))
         assert result["action_count"] == 1
 

--- a/tests/training.test.js
+++ b/tests/training.test.js
@@ -51,6 +51,12 @@ assert.match(pagesSource, /id="train-prime-setup-modal"/);
 assert.match(pagesSource, /src="\/logos\/prime\.png"/);
 
 const starterConfig = fs.readFileSync(path.join(ROOT_DIR, "configs", "rl", "mazebench.toml"), "utf8");
+const primeSystemPrompt = fs.readFileSync(
+  path.join(ROOT_DIR, "environments", "mazebench", "mazebench", "prompts", "multiturn_system.txt"),
+  "utf8"
+);
+assert.doesNotMatch(primeSystemPrompt, /If you are unsure[\s\S]*respond with `up`/);
+assert.match(primeSystemPrompt, /If it says `Moved: false`, that movement was blocked/);
 assert.match(starterConfig, /max_steps = 10/);
 assert.match(starterConfig, /batch_size = 32/);
 assert.match(starterConfig, /rollouts_per_example = 4/);
@@ -139,16 +145,35 @@ const observationPolicyProbe = execFileSync(
     "python",
     "-c",
     [
-      "from mazebench.mazebench import action_result_text,render_json_user_prompt,render_multiturn_user_prompt,render_vision_user_prompt",
+      "from mazebench.mazebench import action_result_text,render_json_user_prompt,render_multiturn_user_prompt,render_vision_user_prompt,slim_status",
       "s={'allowed_commands':['up'],'current_room':'level_HxI','current_view':'top-diagonal','gem_count':0,'json_observation':{'objects':{'player':[[4,15,0]]}},'level':'P..','player':{'x':4,'y':15,'elevation':0},'scorecard':{'current_position':{'x':4,'y':15,'elevation':0}},'visited_levels':['level_HxI'],'yaw':0}",
       "t=render_multiturn_user_prompt(status=s,target_text='play',result_text='start')",
       "v=render_vision_user_prompt(status=s,target_text='play',result_text='start')",
       "j=render_json_user_prompt(status=s,target_text='play',result_text='start')",
+      "blocked_result=action_result_text(command='move',status={**s,'action':'move','direction':'up','moved':False})",
+      "blocked=render_multiturn_user_prompt(status=s,target_text='play',result_text=blocked_result)",
+      "successful_result=action_result_text(command='move',status={**s,'action':'move','direction':'right','moved':True})",
+      "successful=render_multiturn_user_prompt(status=s,target_text='play',result_text=successful_result)",
+      "progress_result=action_result_text(command='move',status={**s,'action':'move','direction':'right','moved':True,'room_changed':True,'current_room':'level_IxI','collected_this_action':['gem-1']})",
+      "progress=render_multiturn_user_prompt(status=s,target_text='play',result_text=progress_result)",
+      "invalid=render_multiturn_user_prompt(status=s,target_text='play',result_text=action_result_text(error='bad command'))",
+      "warning=render_multiturn_user_prompt(status=s,target_text='play',result_text=blocked_result+'\\n\\nAUTO-QUIT WARNING: change course')",
+      "dead_status={**s,'player_dead':True}",
+      "dead_result=action_result_text(command='move',status={**dead_status,'action':'move','direction':'up','moved':False})",
+      "dead=render_multiturn_user_prompt(status=dead_status,target_text='play',result_text=dead_result)",
       "assert 'Player:' not in t and 'elevation=0' not in t",
       "assert 'Current room:' not in t and 'Current view:' not in t and 'Yaw:' not in t",
       "assert 'Gems collected:' not in t and 'Visited rooms:' not in t",
       "assert 'level_HxI' not in t and 'scorecard' not in t.lower()",
       "assert 'P..' in t",
+      "assert 'Previous action: move. Direction: up. Moved: false.' in blocked",
+      "assert 'Previous action: move. Direction: right. Moved: true.' in successful",
+      "assert 'Entered room: level_IxI.' in progress and 'Collected gems: gem-1.' in progress",
+      "assert 'Previous response was invalid: bad command' in invalid",
+      "assert warning.count('AUTO-QUIT WARNING: change course') == 1",
+      "assert dead.count('The player died, you must now undo or reset or go to a level.') == 1",
+      "assert 'scorecard' not in blocked.lower() and 'x=4' not in blocked and 'y=15' not in blocked",
+      "assert slim_status({'direction':'up'})['direction'] == 'up'",
       "assert 'Player:' not in v and 'elevation=0' not in v",
       "assert 'Player: x=4 y=15 elevation=0' in j",
       "assert 'scorecard' not in action_result_text(command='quit',status={**s,'quit':True}).lower()",


### PR DESCRIPTION
## Summary

- include the sanitized previous action result in every Prime ASCII observation
- preserve movement direction in resumable Prime status snapshots
- replace the unconditional `up` fallback with explicit blocked-move guidance
- cover successful, blocked, invalid, progress, death, auto-quit, privacy, and resume behavior

## Root cause

Prime already computed `Moved: true` or `Moved: false`, but the ASCII prompt renderer discarded normal action results and retained only invalid-response, auto-quit, and death notices. The system prompt then told an uncertain model to default to `up`, creating a repeatable stuck loop.

## Impact

Prime text-mode models now receive the same essential action-success signal available to the local Codex and Claude Code harnesses without exposing coordinates, scorecards, hidden names, or repository state.

## Validation

- `node tests/training.test.js`
- `node tests/prime-resume-environment.test.js`
- `node tests/prime-hosted-eval.test.js`
- `node tests/prime-verifiers-auto-quit.test.js`
- `node tests/prime-harnesses.test.js`
- `npm test`
