### PR TITLE
Bump Prime environment to 0.1.9

### DIFF
--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.8"
+version = "0.1.9"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -77,7 +77,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.8
+prime env install mazebench/mazebench@0.1.9
 ```
 
 ## Evaluate locally

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.8"
+version = "0.1.9"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },


### PR DESCRIPTION
## Summary

- bump the standalone Prime environment package from 0.1.8 to 0.1.9
- update the hosted-training config pin and versioned install documentation
- refresh the environment lockfile's local package version

## Why

Version 0.1.9 publishes the merged Prime action-feedback behavior so ASCII observations report successful and blocked moves instead of silently encouraging repeated `up` actions.

## Validation

- built `mazebench-0.1.9` wheel and source distribution
- packaged prompt smoke test for `Direction: up. Moved: false.`
- `node tests/training.test.js`
- `node tests/prime-resume-environment.test.js`
- `node tests/runtime-drift.test.js`
- merged behavior commit passed full `main` CI and Python 3.9/3.14 wheel-smoke jobs
