### PR TITLE
Release MazeBench 0.2.10 and Prime environment 0.1.10

### DIFF
--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.9"
+version = "0.1.10"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -77,7 +77,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.9
+prime env install mazebench/mazebench@0.1.10
 ```
 
 ## Evaluate locally

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },

--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -32,7 +32,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.9"
+version = "0.2.10"
 description = "MazeBench: ice-maze puzzle site, world editor, and coding-agent benchmark runner. `mazebench launch` serves the website locally."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- bump the PyPI package and CLI runtime to 0.2.10
- bump the Prime Environment Hub package and training pin to 0.1.10
- update the pinned Prime install example

## Why

This publishes the engine, editor, replay, agent-runner, and Prime environment improvements merged since the 0.2.9 / 0.1.9 releases.

## Validation

- `uv lock --check` (root and Prime environment)
- `node scripts/build-python-runtime.js`
- `uv build --clear`
- `npm test`
- clean wheel install and packaged-site launch smoke on Python 3.9 and 3.14