### PR TITLE
release: bump version to 0.2.11

### DIFF
--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -32,7 +32,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.10"
+version = "0.2.11"
 description = "Build and play persistent 3D worlds, then benchmark coding agents and Prime Intellect Verifiers against them."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- bump the root PyPI package from `0.2.10` to `0.2.11`
- keep `pyproject.toml`, `mazebench_cli.__version__`, and `uv.lock` synchronized

## Why

This patch release publishes the new minimal PyPI README merged in #66. PyPI reads that description from release metadata, so a new immutable package version is required.

## Impact

The package runtime is unchanged. PyPI will display the dedicated 79-word package README after `0.2.11` is published.

## Validation

- rebuilt the packaged Node runtime
- ran the complete `npm test` suite
- built and inspected the `0.2.11` wheel and source distribution
- installed and launched the wheel on Python 3.9.6 and Python 3.14.3
- verified `/`, `/play`, `/build`, `/agent`, game API, and bundled Three.js routes
- ran `uv lock --check`
