### PR TITLE
Force Kimi observation breaks

### DIFF
--- a/environments/mazebench/mazebench_tools/__init__.py
+++ b/environments/mazebench/mazebench_tools/__init__.py
@@ -38,6 +38,13 @@ from mazebench.mazebench import (
 )
 
 
+KIMI_CODE_OBSERVE_INTERVAL = 5
+
+
+def _prime_harness_id() -> str:
+    return os.environ.get("MAZEBENCH_PRIME_HARNESS", "").strip().lower().replace("-", "_")
+
+
 class MazeBenchToolsetConfig(vf.ToolsetConfig):
     """Private evaluator-owned paths supplied when a rollout tool server starts."""
 
@@ -110,12 +117,20 @@ def _tool_prompt(task: MazeBenchTaskData) -> str:
         else "Quit is disabled; recover with undo or reset after a death and keep playing."
     )
     mode = "structured JSON" if task.observation_mode == "json" else "ASCII"
+    kimi_observe_policy = (
+        "\n\nKimi Code compatibility rule: after five consecutive `game_action` calls, "
+        "you must call `game_observe` once before any further `game_action`. "
+        "The fifth action result reports `observe_required: true`; treat it as mandatory. "
+        "`game_observe` resets the count and does not consume a game action."
+        if _prime_harness_id() == "kimi_code"
+        else ""
+    )
     return f"""Play the hidden 3D grid game using only the supplied game controls.
 
 Call `game_start` exactly once first. Inspect its sanitized {mode} observation, then call
 `game_action` with one action at a time. Use `game_observe` only when you need to inspect the
 current state without consuming an action. Valid actions include up, down, left, right,
-rotate camera left, rotate camera right, undo, reset, and go to level X Y.
+rotate camera left, rotate camera right, undo, reset, and go to level X Y.{kimi_observe_policy}
 
 Collect {int(task.target_gems)} gems and explore as many rooms as possible. {budget} {quit_policy}
 When the returned result says `ended: true`, finish with a short route summary.
@@ -160,6 +175,10 @@ class MazeBenchToolset(vf.Toolset[MazeBenchToolsetConfig]):
         self._lock = asyncio.Lock()
         self._closed = False
         self._actions: list[dict[str, Any]] = []
+        self._observe_break_interval = (
+            KIMI_CODE_OBSERVE_INTERVAL if _prime_harness_id() == "kimi_code" else 0
+        )
+        self._actions_since_observe = 0
         self._auto_quit: dict[str, Any] = {}
         self._scorecard: dict[str, Any] = {}
         self._status_error = ""
@@ -320,6 +339,13 @@ class MazeBenchToolset(vf.Toolset[MazeBenchToolsetConfig]):
             ),
             "ended": self._terminal(),
         }
+        if (
+            not result["ended"]
+            and self._observe_break_interval
+            and self._actions_since_observe >= self._observe_break_interval
+        ):
+            result["observe_required"] = True
+            result["next_required_tool"] = "game_observe"
         if error:
             result["error"] = error
         if self._auto_quit:
@@ -341,6 +367,7 @@ class MazeBenchToolset(vf.Toolset[MazeBenchToolsetConfig]):
         """Return the current sanitized observation without consuming an action."""
 
         async with self._lock:
+            self._actions_since_observe = 0
             return self._result()
 
     @vf.tool
@@ -350,6 +377,15 @@ class MazeBenchToolset(vf.Toolset[MazeBenchToolsetConfig]):
         async with self._lock:
             if self._terminal():
                 return self._result(error="The run has ended; no further action is available.")
+            if (
+                self._observe_break_interval
+                and self._actions_since_observe >= self._observe_break_interval
+            ):
+                return self._result(
+                    error="Call game_observe before another game_action."
+                )
+
+            self._actions_since_observe += 1
 
             raw = str(action or "").strip()
             blocked_quit = False

--- a/tests/prime-harnesses.test.js
+++ b/tests/prime-harnesses.test.js
@@ -150,6 +150,105 @@ try {
   assert.match(toolsTasksetSource, /user = None/);
   assert.match(toolsTasksetSource, /trace\.state = trusted_state/);
   assert.match(toolsTasksetSource, /__all__ = \["MazeBenchToolTaskset"\]/);
+  assert.match(toolsTasksetSource, /KIMI_CODE_OBSERVE_INTERVAL = 5/);
+  assert.match(toolsTasksetSource, /next_required_tool.*game_observe/s);
+  assert.match(toolsTasksetSource, /Call game_observe before another game_action/);
+
+  const kimiObserveProbe = spawnSync(
+    "uv",
+    [
+      "run",
+      "--project",
+      path.join(root, "environments", "mazebench"),
+      "python",
+      "-c",
+      `import asyncio
+import os
+from types import SimpleNamespace
+
+import mazebench_tools as module
+
+
+prompt_task = SimpleNamespace(
+    allow_quit=False,
+    max_actions=None,
+    observation_mode="ascii",
+    target_gems=0,
+)
+os.environ["MAZEBENCH_PRIME_HARNESS"] = "kimi-code"
+assert "Kimi Code compatibility rule" in module._tool_prompt(prompt_task)
+os.environ["MAZEBENCH_PRIME_HARNESS"] = "codex"
+assert "Kimi Code compatibility rule" not in module._tool_prompt(prompt_task)
+
+
+async def probe():
+    toolset = module.MazeBenchToolset(config=module.MazeBenchToolsetConfig())
+    toolset.task = SimpleNamespace(
+        allow_quit=True,
+        auto_quit=False,
+        auto_quit_mode="cumulative",
+        auto_quit_threshold=0.0,
+        auto_quit_window=100,
+        game_won_gem_count=999,
+        max_actions=None,
+        observation_mode="ascii",
+    )
+    toolset._lock = asyncio.Lock()
+    toolset._closed = False
+    toolset._actions = []
+    toolset._observe_break_interval = module.KIMI_CODE_OBSERVE_INTERVAL
+    toolset._actions_since_observe = 0
+    toolset._auto_quit = {}
+    toolset._scorecard = {}
+    toolset._status_error = ""
+    toolset._initial_hash = "state-0"
+    toolset._status = {
+        "action_count": 0,
+        "board_state_hash": "state-0",
+        "game_lost": False,
+        "game_won": False,
+        "quit": False,
+        "gem_count": 0,
+    }
+    toolset._session = SimpleNamespace(request=lambda *args, **kwargs: None)
+    toolset._write_snapshot = lambda: None
+
+    async def fake_run_blocking(_func, command, **_kwargs):
+        if command == "observe":
+            return dict(toolset._status)
+        next_action = len(toolset._actions) + 1
+        return {
+            **toolset._status,
+            "action_count": next_action,
+            "board_state_hash": f"state-{next_action}",
+            "moved": True,
+        }
+
+    module.run_blocking = fake_run_blocking
+
+    for _ in range(5):
+        fifth = await toolset.action("up")
+    assert fifth["actions_used"] == 5
+    assert fifth["observe_required"] is True
+    assert fifth["next_required_tool"] == "game_observe"
+
+    blocked = await toolset.action("up")
+    assert blocked["actions_used"] == 5
+    assert blocked["error"] == "Call game_observe before another game_action."
+
+    observed = await toolset.observe()
+    assert "observe_required" not in observed
+    resumed = await toolset.action("up")
+    assert resumed["actions_used"] == 6
+
+
+asyncio.run(probe())
+print("kimi observe break ready")`
+    ],
+    { cwd: root, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }
+  );
+  assert.equal(kimiObserveProbe.status, 0, kimiObserveProbe.stderr || kimiObserveProbe.stdout);
+  assert.match(kimiObserveProbe.stdout, /kimi observe break ready/);
 
   assert.equal(primeHarnessModelCompatible("openai/gpt-5-codex", "codex"), true);
   assert.equal(primeHarnessModelCompatible("openai/gpt-4.1", "codex"), true);


### PR DESCRIPTION
## Summary

- tell Kimi Code to call `game_observe` after every five consecutive `game_action` calls
- mark the fifth action result as observation-required and reject further actions until it observes
- keep all other Prime harness behavior unchanged
- add a focused regression probe for the five-action boundary and reset behavior

## Root cause

Kimi Code 0.27.0 deduplicates repeated tool calls by tool name and arguments. A legitimate sequence of identical maze moves can therefore trigger Kimi's repetition guard even while the returned game state changes, causing the harness to finish early.

## Impact

Kimi receives a distinct, non-action tool call before its repetition guard reaches the forced-final-response threshold. The observation consumes no MazeBench action, and a blocked sixth action cannot mutate game state.

## Validation

- `node tests/prime-harnesses.test.js`
- `npm run test:pr`
- `npm test`
- `node tests/runtime-drift.test.js`
- Python bytecode compilation and `git diff --check`
- launched a live Kimi K3 run with the patched evaluator
