### PR TITLE
Release MazeBench 0.2.12 and Prime environments

### DIFF
--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.10"
+version = "0.1.11"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -79,7 +79,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.10
+prime env install mazebench/mazebench@0.1.11
 ```
 
 ## Evaluate locally

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.10"
+version = "0.1.11"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },

--- a/environments/mazebench_agent/pyproject.toml
+++ b/environments/mazebench_agent/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench-agent"
 description = "Harness-neutral MazeBench taskset for Prime-managed coding agents."
 tags = ["maze", "game", "agentic", "codex", "claude-code", "eval"]
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench_agent/uv.lock
+++ b/environments/mazebench_agent/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "mazebench-agent"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "verifiers" },

--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -34,7 +34,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.11"
+version = "0.2.12"
 description = "Build and play persistent 3D worlds, then benchmark coding agents and Prime Intellect Verifiers against them."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps the PyPI package to 0.2.12, the Prime MazeBench environment to 0.1.11, and the Prime mazebench-agent environment to 0.1.1. Updates all corresponding lockfiles, the training config pin, and the reproducible install example.

Validation:
- complete npm test suite
- Python CLI unit tests
- Prime auto-quit Python tests
- lock checks and environment imports for both Prime packages
- clean wheel and sdist build
- wheel smoke on Python 3.9 and 3.14
- packaged launch routes returned HTTP 200