### PR TITLE
release: MazeBench 0.2.17

### DIFF
--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -35,7 +35,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.16"
+__version__ = "0.2.17"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.16"
+version = "0.2.17"
 description = "Build and play persistent 3D worlds, then benchmark coding agents and Prime Intellect Verifiers against them."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.16"
+version = "0.2.17"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump the root MazeBench package from 0.2.16 to 0.2.17
- keep pyproject, CLI version, and root lock metadata synchronized
- prepare the responsiveness, semantic color, and JSON grid fixes for PyPI

## Validation
- main CI green before branching
- npm test
- staged 641-file Python runtime (0.2.17+80f52b2d054a)
- built mazebench-0.2.17 wheel and sdist
- installed wheel and passed ASCII, JSON, and site-route smoke tests on Python 3.9 and 3.14
- confirmed PyPI currently has 0.2.16