### PR TITLE
fix: use packaged Node in Prime environment

### DIFF
--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.16"
+version = "0.1.17"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -87,7 +87,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.16
+prime env install mazebench/mazebench@0.1.17
 ```
 
 ## Evaluate with Prime Sandboxes

--- a/environments/mazebench/mazebench/mazebench.py
+++ b/environments/mazebench/mazebench/mazebench.py
@@ -10,6 +10,7 @@ import select
 import shlex
 import signal
 import subprocess
+import sys
 from datetime import datetime, timezone
 from importlib.resources import files
 from pathlib import Path
@@ -57,7 +58,16 @@ DEFAULT_GAME_ID = "maze"
 DEFAULT_START_LEVEL_ID = os.environ.get("MAZEBENCH_START_LEVEL_ID", "level_HxI")
 DEFAULT_VIEW = "top-diagonal"
 DEFAULT_YAW = 0
-DEFAULT_NODE_BIN = "node"
+
+
+def resolve_default_node_bin(
+    python_executable: str | Path | None = None,
+) -> str:
+    packaged_node = Path(python_executable or sys.executable).with_name("node")
+    return str(packaged_node) if packaged_node.is_file() else "node"
+
+
+DEFAULT_NODE_BIN = resolve_default_node_bin()
 DEFAULT_TIMEOUT_SECONDS = 20
 DEFAULT_MAX_ACTIONS = env_int("MAZEBENCH_MAX_ACTIONS", 256, minimum=1)
 DEFAULT_TARGET_GEMS = 0

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.16"
+version = "0.1.17"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -854,7 +854,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },

--- a/tests/test_game_runtime_isolation.py
+++ b/tests/test_game_runtime_isolation.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import os
+import tempfile
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -12,6 +13,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import mazebench_tools
+from mazebench.mazebench import resolve_default_node_bin
 import verifiers.v1.mcp.launch as mcp_launch
 import verifiers.v1.rollout as rollout_module
 from mcp.types import CallToolResult, ImageContent
@@ -46,6 +48,19 @@ EXPECTED_GAME_TOOLS = {
 
 
 class GameRuntimeIsolationTests(unittest.TestCase):
+    def test_default_node_uses_the_packaged_python_sibling(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            bin_dir = Path(temporary_dir) / "bin"
+            bin_dir.mkdir()
+            python = bin_dir / "python"
+            node = bin_dir / "node"
+            node.touch()
+
+            self.assertEqual(resolve_default_node_bin(python), str(node))
+
+            node.unlink()
+            self.assertEqual(resolve_default_node_bin(python), "node")
+
     def test_tool_server_uses_a_dedicated_prime_runtime(self) -> None:
         config = mazebench_tools.MazeBenchToolsetConfig()
 


### PR DESCRIPTION
## Summary

- resolve the Node executable installed by `nodejs-wheel` beside the active Python interpreter
- retain `node` as the source-checkout fallback
- add regression coverage for packaged and fallback resolution
- publish the immutable recovery version as Prime environment `0.1.17`

## Root cause

Prime Hub `0.1.16` installed `nodejs-wheel` successfully but its quality runner does not put Node on the global `PATH`. The environment used the literal command `node` while the packaged runtime was available at the virtual environment’s `bin/node`, so Hub `test_load` and `test_eval` failed before evaluation.

## Verification

- reproduced the exact Hub failure from action `huunhqos48eufwacq45m9yfy`
- exact Hub-style `vf.load_environment("mazebench")` succeeds with the packaged Node path
- Prime isolation suite: 10 tests passed, 2 skipped
- full `npm test` passed
- Python CLI tests passed (6 tests)
- root and Prime `uv lock --check` passed
- `git diff --check` passed
