### PR TITLE
Release MazeBench 0.2.19 and Prime 0.1.18

### DIFF
--- a/configs/rl/mazebench.toml
+++ b/configs/rl/mazebench.toml
@@ -13,7 +13,7 @@ temperature = 1.0
 
 [[env]]
 id = "mazebench/mazebench"
-version = "0.1.17"
+version = "0.1.18"
 
 [env.args]
 num_train_examples = 1

--- a/environments/mazebench/README.md
+++ b/environments/mazebench/README.md
@@ -87,7 +87,7 @@ prime env install mazebench/mazebench
 Install a specific version for reproducibility:
 
 ```bash
-prime env install mazebench/mazebench@0.1.17
+prime env install mazebench/mazebench@0.1.18
 ```
 
 ## Evaluate with Prime Sandboxes

--- a/environments/mazebench/pyproject.toml
+++ b/environments/mazebench/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mazebench"
 description = "JS-backed ASCII maze benchmark for multi-turn language models."
 tags = ["maze", "game", "ascii", "reasoning", "train", "eval"]
-version = "0.1.17"
+version = "0.1.18"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/environments/mazebench/uv.lock
+++ b/environments/mazebench/uv.lock
@@ -854,7 +854,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "nodejs-wheel" },

--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -28,7 +28,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 
 USAGE = """mazebench — run the MazeBench maze game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mazebench"
-version = "0.2.18"
+version = "0.2.19"
 description = "Build and play persistent 3D worlds, then benchmark coding agents and Prime Intellect Verifiers against them."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1279,7 +1279,7 @@ wheels = [
 
 [[package]]
 name = "mazebench"
-version = "0.2.18"
+version = "0.2.19"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump the root PyPI package to 0.2.19
- bump the bundled Prime environment to 0.1.18
- keep the RL config and installation docs synchronized

## Verification
- exact merged Engine main CI passed, including Python 3.9 and 3.14 wheel smokes
- `npm run test:pr` completed in 9s
- Python CLI tests passed
- locally built and verified `mazebench-0.2.19` wheel and sdist

The user explicitly approved the package, Prime, MazeJam, and production release.