### PR TITLE
Fix mazebench launch crash on Windows

### DIFF
--- a/mazebench_cli/__init__.py
+++ b/mazebench_cli/__init__.py
@@ -296,9 +296,44 @@ def _server_log() -> Path:
     return _mazebench_home() / "server.log"
 
 
+def _windows_pid_alive(pid: int) -> bool:
+    """Check a Windows process without signalling or terminating it."""
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    error_access_denied = 5
+    still_active = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    open_process.restype = wintypes.HANDLE
+    get_exit_code = kernel32.GetExitCodeProcess
+    get_exit_code.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    get_exit_code.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(process_query_limited_information, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        exit_code = wintypes.DWORD()
+        return bool(get_exit_code(handle, ctypes.byref(exit_code))) and (
+            exit_code.value == still_active
+        )
+    finally:
+        close_handle(handle)
+
+
 def _pid_alive(pid: int) -> bool:
     if not pid or pid <= 0:
         return False
+    if sys.platform == "win32":
+        # On Windows, os.kill(pid, 0) calls TerminateProcess instead of probing.
+        return _windows_pid_alive(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/tests/test_mazebench_cli.py
+++ b/tests/test_mazebench_cli.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 from pathlib import Path
 from unittest import TestCase, mock
 
@@ -13,6 +16,20 @@ class CliCommandTests(TestCase):
         self.assertEqual(result, 0)
         resolve_root.assert_not_called()
         print_output.assert_called_once_with(mazebench_cli.USAGE)
+
+    def test_pid_liveness_probe_does_not_terminate_process(self):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"]
+        )
+        try:
+            self.assertTrue(mazebench_cli._pid_alive(proc.pid))
+            with self.assertRaises(subprocess.TimeoutExpired):
+                proc.wait(timeout=0.1)
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+            proc.wait(timeout=5)
+
 
     @mock.patch.object(mazebench_cli, "run_ascii", return_value=23)
     @mock.patch.object(mazebench_cli, "resolve_root", return_value=Path("/maze"))


### PR DESCRIPTION
## Summary
- replace the destructive Windows `os.kill(pid, 0)` liveness probe with a read-only Win32 process query
- preserve the existing POSIX liveness probe
- add a regression test proving a liveness check leaves the target process running

## Verification
- `python -m unittest tests.test_mazebench_cli`
- launched `mazebench launch` with browser opening enabled; server reached `http://127.0.0.1:3000`
- `mazebench status` reported the live server without terminating it
- loaded the Maze Bench home page in Chromium
- `mazebench stop` removed the live server state